### PR TITLE
Slack notification: fix bug with mention when updating message fail

### DIFF
--- a/src/plugins/slack/notifications/slack_notification.py
+++ b/src/plugins/slack/notifications/slack_notification.py
@@ -266,12 +266,7 @@ async def update_notification(
     """Update a Slack message. If the update fails but the error indicates the message should be
     re-sent, send it again, otherwise just log an error"""
     ts = notification.data["ts"]
-
-    response = await slack.update(
-        channel=channel,
-        ts=ts,
-        attachments=attachments,
-    )
+    response = await slack.update(channel=channel, ts=ts, attachments=attachments)
 
     if not response["ok"]:
         if response["error"] in RESEND_ERRORS:
@@ -279,6 +274,10 @@ async def update_notification(
                 f"Unable to update message for {monitor} alert {notification.alert_id} "
                 f"with error '{response['error']}', resending"
             )
+
+            # If sending a new notification message, clear the mention message so it'll be sent
+            # again in the new message thread
+            notification.data["mention_ts"] = None
 
             await send_notification(
                 monitor=monitor,

--- a/tests/plugins/slack/notifications/test_slack_notification.py
+++ b/tests/plugins/slack/notifications/test_slack_notification.py
@@ -526,7 +526,7 @@ async def test_update_notification_error_resend(
         monitor_id=sample_monitor.id,
         alert_id=alert.id,
         target="slack",
-        data={"channel": "channel", "ts": "1111"},
+        data={"channel": "channel", "ts": "1111", "mention_ts": "123"},
     )
 
     await slack_notification.update_notification(
@@ -538,7 +538,7 @@ async def test_update_notification_error_resend(
 
     loaded_notification = await Notification.get_by_id(notification.id)
     assert loaded_notification is not None
-    assert loaded_notification.data == {"channel": "channel", "ts": "999"}
+    assert loaded_notification.data == {"channel": "channel", "ts": "999", "mention_ts": None}
     assert_message_in_log(caplog, "Unable to update message for")
     assert_message_in_log(caplog, "resending")
 
@@ -547,8 +547,8 @@ async def test_update_notification_error_resend(
 async def test_update_notification_error_no_resend(
     caplog, monkeypatch, sample_monitor: Monitor, update_error
 ):
-    """'update_notification' should update a message in the channel and if it fails and just fail
-    if the error doesn't indicate that the message should be sent again"""
+    """'update_notification' should update a message in the channel and if it fails and if the
+    error doesn't indicate that the message should be sent again, it should log an error"""
     monkeypatch.setattr(slack_mock, "response_ts", "123")
     update_response = AsyncMock(
         return_value=AsyncSlackResponse(


### PR DESCRIPTION
If updating a Slack notification has an error and the message will be sent again, the mention timestamp must be cleared, so it'll be sent again in the new message thread